### PR TITLE
Fix docs typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An abstraction layer for NoSQL Database with features used in the financial serv
 
  * Simple factory. A single URL would define the database or union.
  
- * Filesystem-like heirachy for objects.
+ * Filesystem-like hierarchy for objects.
  
  * Caching and cache context.
  

--- a/docsrc/source/index.rst
+++ b/docsrc/source/index.rst
@@ -13,7 +13,7 @@ An abstraction layer for NoSQL Database with features used in the financial serv
 
  * Simple factory. A single URL would define the database or union.
  
- * Filesystem-like heirachy for objects.
+ * Filesystem-like hierarchy for objects.
  
  * Caching and cache context.
  


### PR DESCRIPTION
## Summary
- fix minor typo in README
- fix same typo in docs

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684515a45694832183fd0728b0e7a6fb