### PR TITLE
Enhance automated tests and docs

### DIFF
--- a/docsrc/source/developer.rst
+++ b/docsrc/source/developer.rst
@@ -27,3 +27,17 @@ You would need to set the following environment variables:
  
  * ``KINYU_UNITTEST_REDIS_HOST``: host of the redis server. Can also end with :port if non standard port. i.e. redis-host:8765
 
+To limit the database types tested you can set ``KYDB_TEST_DB_TYPES`` with
+a comma separated list such as ``dynamodb`` or ``s3,redis``.  When running
+locally without real infrastructure you can spin up in-memory services by
+setting ``KYDB_TEST_LOCAL_SERVICES`` with the services to mock
+(``s3``, ``dynamodb``, ``redis``).  Using local services requires the
+extra dependencies ``moto`` and ``fakeredis``.
+
+To run the tests under Codex or CI you should execute them from the project
+root::
+
+    export PYTHONPATH=.
+    IS_AUTOMATED_UNITTEST=1 pytest kydb
+
+

--- a/kydb/impl/tests/conftest.py
+++ b/kydb/impl/tests/conftest.py
@@ -1,0 +1,93 @@
+import os
+import boto3
+import pytest
+from contextlib import ExitStack
+
+
+@pytest.fixture(scope="session", autouse=True)
+def local_services():
+    """Spin up local services for testing if requested.
+
+    The environment variable ``KYDB_TEST_LOCAL_SERVICES`` accepts a comma
+    separated list of services (``s3``, ``dynamodb``, ``redis``).  Required
+    third-party libraries must be installed otherwise the tests will be
+    skipped.
+    """
+    services = {
+        s.strip() for s in os.environ.get("KYDB_TEST_LOCAL_SERVICES", "").split(",") if s.strip()
+    }
+    if not services:
+        yield
+        return
+
+    stack = ExitStack()
+    missing = []
+
+    if "s3" in services:
+        try:
+            from moto import mock_s3
+        except ImportError:
+            missing.append("moto")
+        else:
+            m = mock_s3()
+            stack.enter_context(m)
+            s3 = boto3.client("s3", region_name="us-east-1")
+            bucket = os.environ.get("KINYU_UNITTEST_S3_BUCKET", "kydb-test")
+            s3.create_bucket(Bucket=bucket)
+
+    if "dynamodb" in services:
+        try:
+            from moto import mock_dynamodb2
+        except ImportError:
+            missing.append("moto")
+        else:
+            m = mock_dynamodb2()
+            stack.enter_context(m)
+            dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+            table = os.environ.get("KINYU_UNITTEST_DYNAMODB", "kydb-test-table")
+            dynamodb.create_table(
+                TableName=table,
+                KeySchema=[{"AttributeName": "path", "KeyType": "HASH"}],
+                AttributeDefinitions=[
+                    {"AttributeName": "path", "AttributeType": "S"},
+                    {"AttributeName": "folder", "AttributeType": "S"},
+                ],
+                ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+                GlobalSecondaryIndexes=[
+                    {
+                        "IndexName": "folder-index",
+                        "KeySchema": [{"AttributeName": "folder", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                        "ProvisionedThroughput": {
+                            "ReadCapacityUnits": 5,
+                            "WriteCapacityUnits": 5,
+                        },
+                    }
+                ],
+            )
+
+    if "redis" in services:
+        try:
+            import redis
+            import fakeredis
+        except ImportError:
+            missing.append("fakeredis")
+        else:
+            server = fakeredis.FakeServer()
+            original = redis.Redis
+
+            def fake_constructor(*args, **kwargs):
+                return fakeredis.FakeRedis(server=server, *args, **kwargs)
+
+            redis.Redis = fake_constructor
+
+            def restore():
+                redis.Redis = original
+
+            stack.callback(restore)
+
+    if missing:
+        pytest.skip("Missing local service dependencies: {}".format(", ".join(sorted(set(missing)))))
+
+    with stack:
+        yield

--- a/kydb/impl/tests/test_http.py
+++ b/kydb/impl/tests/test_http.py
@@ -1,6 +1,12 @@
 import kydb
 from datetime import datetime
+import os
 import pytest
+
+pytestmark = pytest.mark.skipif(
+    "IS_AUTOMATED_UNITTEST" in os.environ,
+    reason="Automated test does not have HTTP setup",
+)
 
 BASE_URL = 'https://files.tayglobal.com/kinyu-demo'
 

--- a/kydb/impl/tests/test_impl.py
+++ b/kydb/impl/tests/test_impl.py
@@ -11,9 +11,18 @@ def is_automated_test() -> bool:
     return os.environ.get('IS_AUTOMATED_UNITTEST')
 
 
-ALL_DB_TYPES = ['memory', 'files', 'union'] \
-    if is_automated_test() \
-    else ['memory', 's3', 'redis', 'dynamodb', 'files', 'union']
+def get_test_db_types():
+    env_val = os.environ.get('KYDB_TEST_DB_TYPES')
+    if env_val:
+        return [x.strip() for x in env_val.split(',') if x.strip()]
+    return (
+        ['memory', 'files', 'union']
+        if is_automated_test()
+        else ['memory', 's3', 'redis', 'dynamodb', 'files', 'union']
+    )
+
+
+ALL_DB_TYPES = get_test_db_types()
 
 # ALL_DB_TYPES = ['dynamodb']
 BASE_PATHS = ['', 'with_base_path']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ boto3
 redis
 requests
 pyyaml
+fakeredis
+moto


### PR DESCRIPTION
## Summary
- add pytest skip for HTTP tests when IS_AUTOMATED_UNITTEST is set
- document running tests from project root with PYTHONPATH
- allow selecting DB backends with `KYDB_TEST_DB_TYPES`
- add optional local DynamoDB/S3/Redis services using moto and fakeredis
- gracefully skip tests if these extra dependencies aren't installed

## Testing
- `PYTHONPATH=. IS_AUTOMATED_UNITTEST=1 pytest kydb/impl/tests -q`
- `PYTHONPATH=. IS_AUTOMATED_UNITTEST=1 KYDB_TEST_DB_TYPES=dynamodb KYDB_TEST_LOCAL_SERVICES=dynamodb pytest kydb/impl/tests/test_impl.py::test_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_684f64510a448321a5be909e00ee842d